### PR TITLE
feat: save quiz results

### DIFF
--- a/app/(dashboard)/(routes)/courses/[courseId]/chapters/[chapterId]/_components/quiz-section.tsx
+++ b/app/(dashboard)/(routes)/courses/[courseId]/chapters/[chapterId]/_components/quiz-section.tsx
@@ -146,9 +146,24 @@ export const QuizSection = ({ chapterId, chapterTitle, userId }: QuizSectionProp
     return getScorePercentage() >= aiQuiz.passingScore;
   };
 
-  const markAsCompleted = () => {
-    setIsCompleted(true);
-    // TODO: Save completion to database
+  const markAsCompleted = async () => {
+    try {
+      const score = getScorePercentage();
+      const response = await fetch('/api/quiz/complete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ chapterId, userId, score }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to save quiz result');
+      }
+
+      setIsCompleted(true);
+    } catch (error) {
+      console.error(error);
+      toast.error('Error al guardar resultado del quiz');
+    }
   };
 
   const formatTime = (seconds: number) => {

--- a/app/api/quiz/complete/route.ts
+++ b/app/api/quiz/complete/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { defaultLogger } from '@/lib/logger';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { chapterId, userId, score } = await req.json();
+
+    if (!chapterId || !userId || typeof score !== 'number') {
+      return new NextResponse('Invalid data', { status: 400 });
+    }
+
+    const result = await db.quizResult.upsert({
+      where: {
+        userId_chapterId: {
+          userId,
+          chapterId,
+        },
+      },
+      update: {
+        score,
+      },
+      create: {
+        userId,
+        chapterId,
+        score,
+      },
+    });
+
+    defaultLogger.info('Quiz result stored', { userId, chapterId, score });
+
+    return NextResponse.json(result);
+  } catch (error: any) {
+    defaultLogger.error('[QUIZ_COMPLETE]', error);
+    return new NextResponse('Internal Error', { status: 500 });
+  }
+}

--- a/prisma/migrations/add_quiz_result.sql
+++ b/prisma/migrations/add_quiz_result.sql
@@ -1,0 +1,16 @@
+-- 📝 MIGRACIÓN PARA RESULTADOS DE QUIZ
+-- Crea la tabla QuizResult relacionada con usuarios y capítulos
+
+CREATE TABLE IF NOT EXISTS "QuizResult" (
+  "id" TEXT NOT NULL PRIMARY KEY,
+  "userId" TEXT NOT NULL,
+  "chapterId" TEXT NOT NULL,
+  "score" INT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "QuizResult_chapterId_fkey" FOREIGN KEY ("chapterId") REFERENCES "Chapter"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "QuizResult_userId_chapterId_key" ON "QuizResult"("userId", "chapterId");
+CREATE INDEX IF NOT EXISTS "QuizResult_userId_idx" ON "QuizResult"("userId");
+CREATE INDEX IF NOT EXISTS "QuizResult_chapterId_idx" ON "QuizResult"("chapterId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,7 @@ model Chapter {
   course Course @relation(fields: [courseId], references: [id], onDelete: Cascade)
 
   userProgress UserProgress[]
+  quizResults QuizResult[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -109,6 +110,23 @@ model UserProgress {
   @@index([chapterId])
   @@index([userId])
   @@unique([userId, chapterId])
+}
+
+model QuizResult {
+  id String @id @default(uuid())
+  userId String
+
+  chapterId String
+  chapter Chapter @relation(fields: [chapterId], references: [id], onDelete: Cascade)
+
+  score Int
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, chapterId])
+  @@index([userId])
+  @@index([chapterId])
 }
 
 model Purchase {


### PR DESCRIPTION
## Summary
- store quiz results via new `/api/quiz/complete` endpoint
- persist quiz scores with new `QuizResult` Prisma model
- record quiz completion from client before updating state

## Testing
- `npx prisma generate`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for ESLint config and exits)*

------
https://chatgpt.com/codex/tasks/task_e_689ac3a300cc832b8ec6fc67f09a2c06